### PR TITLE
Fix heredoc syntax error in neovim and respect user preferred path configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ let g:gdoc_file_path = '/some-directory'                      " Defaults to '~/.
 let g:token_directory = '/some-directory'                     " Defaults to '~/.vim/'
 ```
 
+[NOTE]: Directories specified must exist - they will not be created by this plugin.
+
 These paths will be valid both on windows and unix as they are passed through [`os.path.expanduser()`](https://docs.python.org/3/library/os.path.html#os.path.expanduser) in python.
 
 - `g:token_directory` is where token for your api should live, if you don't

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ the credentials in the `g:path_to_creds`.
 In the example below, `credentials.json` is placed in `~/.vim` you can use any valid credential file, and put it's path here.
 
 ```vim
-let g:path_to_creds = '~/.vim/credentials.json' " this is required
-let g:gdoc_file_path = '~/.vim/' " optional; default is ./
-let g:token_directory = '~/.vim/' " optional; default is ./
+let g:path_to_creds = '/some-path/some-credentials-file.json' " Defaults to '~/.vim/credentials.json'
+let g:gdoc_file_path = '/some-directory'                      " Defaults to '~/.vim/'
+let g:token_directory = '/some-directory'                     " Defaults to '~/.vim/'
 ```
 
 These paths will be valid both on windows and unix as they are passed through [`os.path.expanduser()`](https://docs.python.org/3/library/os.path.html#os.path.expanduser) in python.

--- a/autoload/gdoc.vim
+++ b/autoload/gdoc.vim
@@ -171,7 +171,7 @@ endfunction
 
 
 function gdoc#FetchDoc(doc_id)
-python3 << EOF
+python3 <<EOF
 
 document_id = vim.eval("a:doc_id")
 

--- a/autoload/gdoc.vim
+++ b/autoload/gdoc.vim
@@ -47,7 +47,7 @@ EOF
 endfunction
 
 function gdoc#RmDoc()
-python3 << EOF 
+python3 << EOF
 target_file_name = vim.eval("expand('%:t')")
 target_file_path = vim.eval("expand('%:p')")
 local_doc = query.open_doc_from_file(target_file_path)
@@ -65,11 +65,11 @@ if local_doc != -1:
         raise GdocErr('Something went wrong')
 else:
     raise GdocErr("Document \"%s\" is not synced with google docs yet, try running :Gdoc write" % target_file_name)
-EOF 
+EOF
 endfunction
 
 function gdoc#SyncDoc()
-python3 << EOF 
+python3 << EOF
 
 
 target_file_name = vim.eval("expand('%:t')")
@@ -87,14 +87,14 @@ if document != -1:
     print('[gdoc.vim] Successfully synced remote doc to local file')
 else:
     raise GdocErr("Document \"%s\" is not synced with google docs yet, try running :Gdoc write" % target_file_name)
-EOF 
+EOF
 
 :edit!
-endfunction 
+endfunction
 
 
 function gdoc#Sync()
-python3 << EOF 
+python3 << EOF
 
 import os
 
@@ -117,7 +117,7 @@ if os.path.exists(query.gdoc_file) and query.open_doc_from_file(fname = target_f
 
 else:
     raise GdocErr("Document \"%s\" is not synced with google docs yet, try running :Gdoc write'" % target_file_name)
-EOF 
+EOF
 
 endfunction
 
@@ -148,7 +148,7 @@ def main():
 
         query.write_id_to_file(doc['id'], target_file_path)
         print("[gdoc.vim] Saved the document ID to %s" % query.gdoc_file)
-        
+
         if query.edit_doc(doc['id'], edit_blob):
             print("[gdoc.vim] Successfully written the document with the id %s"  % doc['id'])
     else:
@@ -171,7 +171,7 @@ endfunction
 
 
 function gdoc#FetchDoc(doc_id)
-python3 << EOF 
+python3 << EOF
 
 document_id = vim.eval("a:doc_id")
 
@@ -179,7 +179,7 @@ try:
     content = query.read_doc(document_id)
 except:
     raise GdocErr(f"Was unable to read document of id '{document_id}' perhaps its invalid?")
-    
+
 extracted_text = query.parse_doc(content)[0]
 lines = extracted_text.split('\n')
 
@@ -193,6 +193,5 @@ target_file_path = vim.eval("expand('%:p')")
 query.write_id_to_file(document_id, target_file_path)
 
 print(f"gdoc.vim: local association created for {document_id}")
-EOF 
+EOF
 endfunction
-

--- a/plugin/gdoc.vim
+++ b/plugin/gdoc.vim
@@ -1,22 +1,22 @@
-let g:path_to_creds = '~/.vim/credentials.json' " this is required
-let g:gdoc_file_path = '~/.vim/' " optional; default is ./
-let g:token_directory = '~/.vim/' " optional; default is ./
-
 if !has('python3')
     echoerr "[gdoc.vim] Python3 is required for gdoc.vim to work."
     finish
 endif
 
-let path_to_creds = get(g:, 'path_to_creds', "-1")
-let token_directory = get(g:, 'token_directory', "./")
+" User can specify paths to credentials file, gdoc and token directory using the expressions:
+"   let g:path_to_creds = '/some-path/some-credentials-file.json'
+"   let g:gdoc_file_path = '/some-directory'
+"   let g:token_directory = '/some-directory'
+
+" If no user specified path exists, we will default to:
+"   ~/.vim/credentials.json for credentials
+" . ~/.vim/ for doc
+" . ~/.vim/ for token directory
+
+let path_to_creds = get(g:, 'path_to_creds', '~/.vim/credentials.json')
+let token_directory = get(g:, 'token_directory', '~/.vim/')
+let gdoc_path = get(g:, 'gdoc_file_path', '~/.vim/')
 let plug_path = fnamemodify(resolve(expand('<sfile>:p')), ':h')
-let gdoc_path = get(g:, 'gdoc_file_path', "./")
-
-
-if path_to_creds == -1
-    echoerr "[gdoc.vim] Please provde the credentials file."
-    finish
-endif
 
 function! GdocComplete(ArgLead, CmdLine, CursorPos)
     return ['sync', 'sync-doc', 'write', 'rm', 'fetch-doc']

--- a/plugin/gdoc.vim
+++ b/plugin/gdoc.vim
@@ -1,5 +1,3 @@
-
-
 let g:path_to_creds = '~/.vim/credentials.json' " this is required
 let g:gdoc_file_path = '~/.vim/' " optional; default is ./
 let g:token_directory = '~/.vim/' " optional; default is ./


### PR DESCRIPTION
Hi @Aadv1k. Thanks for this excellent plugin - I found it when I needed to integrate neovim with good docs.

I am not sure if you are accepting pull requests as you stated that you now use emacs - so feel free to close it.

The syntax `python3 << EOF` does not work on my neovim - so I changed to `python3 <<EOF`. Furthermore, I have refactored the code so that user chosen configurations for credential path etc is respected.

Once again, thanks for the plugin and feel free to close this pull request if you so wish.